### PR TITLE
Add Example of Slow Charging Batteries During Cheap Slots

### DIFF
--- a/examples/automations/slow_charge_during_cheap_periods/README.md
+++ b/examples/automations/slow_charge_during_cheap_periods/README.md
@@ -1,1 +1,40 @@
 # Automation: Solis: Slow Charge During Cheap Periods
+This automation will run every 5 minutes and set the charge rate and times for cheap periods as configured.  This example is configured for the Octopus Cozy tariff which has three cheap periods of:
+- 04:00 - 07:00
+- 13:00 - 16:00
+- 22:00 - 00:00
+
+## Using the script
+To use this script you'll need to validate/modify the following:
+1. Trigger - The default trigger will work fine for you if your rate changes at the top/middle of every hour.
+2. Conditions - You need to modify these such that the script _won't_ run during your cheap slots.  So modify the times and number of cheap slots.
+3. Action - You need to modify the first four lines under `action/data/settings/chargeCurrent`.  These values describe your battery system.  See below for comments.
+4. Fill in your SolisCloud API information under `action/data/config`.  See the root [README.md](/README.md) for more info.
+
+Comments aren't supported inside YAML multi-line blocks, so here are some comments of what's going on in the `action/data/settings/chargeCurrent` section:
+```yaml
+# Set this to your batteries' voltage
+{% set voltage = 50.0 %}
+
+# Set this to your batteries' maximum capacity in watts
+{% set battery_capacity_in_watts = 3650 %}
+
+# Set this to your batteries' maximum charge rate (in amps)
+# You can convert watts to amps via: amps = watts * voltage
+{% set max_charge_amps = 37.5 %}
+
+# If your charging windows are all the same length, just set this to the
+# number of hours.  If you have windows of different length, you need to add
+# the logic here such that charge_hours always is set to the length of the
+# current window.  This example sets the charge_hours to 2 if the hour is
+# between 16 and 23.  Any other time it assumes the cheap slot is three hours
+# long.
+{% set charge_hours = 2 if now().hour > 16 and now().hour < 23 else 3 %}
+
+# Perform calculations to get the charge rate (in amps) for your system.
+{% set battery_soc = float(states('sensor.solis_remaining_battery_capacity'), 0.0) %}
+{% set battery_percent_needed = (100.0 - battery_soc) | round(method="ceil") %}
+{% set watts_hours_needed = battery_capacity_in_watts * (battery_percent_needed/100.0) %}
+{% set amp_hours_needed = (watts_hours_needed/charge_hours) / voltage %}
+{{ min(max(amp_hours_needed | round(method="ceil"), 1), max_charge_amps) }}
+```

--- a/examples/automations/slow_charge_during_cheap_periods/README.md
+++ b/examples/automations/slow_charge_during_cheap_periods/README.md
@@ -38,3 +38,6 @@ Comments aren't supported inside YAML multi-line blocks, so here are some commen
 {% set amp_hours_needed = (watts_hours_needed/charge_hours) / voltage %}
 {{ min(max(amp_hours_needed | round(method="ceil"), 1), max_charge_amps) }}
 ```
+
+## Dashboard card
+Included alongside this automation is a small markdown dashboard card that shows how to print the upcoming charge current that will be set.  This will get updated as your battery is used.  Note that this dashboard will update the state of the charge during charge periods, but the automation will not.  So the value is only accurate just before the charge period starts.

--- a/examples/automations/slow_charge_during_cheap_periods/README.md
+++ b/examples/automations/slow_charge_during_cheap_periods/README.md
@@ -1,0 +1,1 @@
+# Automation: Solis: Slow Charge During Cheap Periods

--- a/examples/automations/slow_charge_during_cheap_periods/README.md
+++ b/examples/automations/slow_charge_during_cheap_periods/README.md
@@ -1,5 +1,5 @@
 # Automation: Solis: Slow Charge During Cheap Periods
-This automation will run every 5 minutes and set the charge rate and times for cheap periods as configured.  This example is configured for the Octopus Cozy tariff which has three cheap periods of:
+This automation will run every 5 minutes and set the charge rate and times for cheap periods as configured.  Battery health is preserved by using the slowest charge rate possible to achieve the maximum charge by the end of the rate.  This example is configured for the Octopus Cozy tariff which has three cheap periods of:
 - 04:00 - 07:00
 - 13:00 - 16:00
 - 22:00 - 00:00

--- a/examples/automations/slow_charge_during_cheap_periods/dashboard_markdown_card.yaml
+++ b/examples/automations/slow_charge_during_cheap_periods/dashboard_markdown_card.yaml
@@ -1,0 +1,19 @@
+type: markdown
+title: Information
+content: |
+  {% set voltage = 50.0 %}
+  {% set battery_capacity_in_watts = 3650 %}
+  {% set max_charge_amps = 37.5 %}
+  {% set charge_hours = 2 if now().hour > 16 and now().hour < 23 else 3 %}
+  {% set battery_soc = float(states('sensor.solis_remaining_battery_capacity'), 0.0) %}
+  {% set battery_percent_needed = (100.0 - battery_soc) | round(method="ceil") %}
+  {% set watts_hours_needed = battery_capacity_in_watts * (battery_percent_needed/100.0) %}
+  {% set amp_hours_needed = (watts_hours_needed/charge_hours) / voltage %}
+
+
+  <table width="100%">
+    <tr>
+      <th valign='top' align='left'>Next Charge Current</th>
+      <td>{{ max(amp_hours_needed | round(method="ceil"), 1) }} A</td>
+    </tr>
+  </table> 

--- a/examples/automations/slow_charge_during_cheap_periods/solis_slow_charge_during_cheap_periods.yaml
+++ b/examples/automations/slow_charge_during_cheap_periods/solis_slow_charge_during_cheap_periods.yaml
@@ -1,0 +1,69 @@
+alias: "Solis: Slow Charge During Cheap Periods"
+description: "Every five minutes, set the charge rate of the batteries such that they will be 100% charged by the end of the upcoming cheap period."
+triggers:
+  # Trigger this automation every 5 minutes.
+  - trigger: time_pattern
+    hours: /1
+    minutes: /5
+conditions:
+  # Don't run during the cheap periods as once we enter the 
+  # cheap period we don't want to adjust the rate of charge 
+  # to the next cheap period.
+  - condition: and
+    conditions:
+      - condition: not
+        conditions:
+          - condition: time
+            after: "04:00:59"
+            before: "06:59:00"
+      - condition: not
+        conditions:
+          - condition: time
+            after: "13:00:59"
+            before: "17:59:00"
+      - condition: not
+        conditions:
+          - condition: time
+            after: "22:00:59"
+            before: "23:59:00"
+actions:
+  - action: pyscript.solis_control_battery_charge
+    metadata: {}
+    data:
+      settings:
+        - chargeCurrent: >-
+            {% set voltage = 50.0 %} # Your batteries' voltage.
+            {% set max_charge_amps = 37.5 %} # The maximum amps your batteries can charge.
+            # Octopus Cozy has two 3-hour slots and one 2-hour slot.  Figure out how
+            # many hours we have this slot.
+            {% set charge_hours = 2 if now().hour > 16 and now().hour < 23 else 3 %}
+            # Calculate lowest amps to charge to get to 100% by the end.
+            {% set battery_soc = float(states('sensor.solis_remaining_battery_capacity'), 0.0) %}
+            {% set battery_percent_needed = (100.0 - battery_soc) | round(method="ceil") %}
+            {% set watts_hours_needed = 3650 * (battery_percent_needed/100.0) %}
+            {% set amp_hours_needed = (watts_hours_needed/charge_hours) / voltage %}
+            {{ min(max(amp_hours_needed | round(method="ceil"), 1), max_charge_amps) }}
+          dischargeCurrent: "0"
+          chargeStartTime: "04:00"
+          chargeEndTime: "06:59"
+          dischargeStartTime: "00:00"
+          dischargeEndTime: "00:00"
+        - chargeCurrent: "0"
+          dischargeCurrent: "0"
+          chargeStartTime: "13:00"
+          chargeEndTime: "15:59"
+          dischargeStartTime: "00:00"
+          dischargeEndTime: "00:00"
+        - chargeCurrent: "0"
+          dischargeCurrent: "0"
+          chargeStartTime: "22:00"
+          chargeEndTime: "23:59"
+          dischargeStartTime: "00:00"
+          dischargeEndTime: "00:00"
+      config:
+        secret: <<API KEY>>
+        key_id: "<<KEY ID>>"
+        username: <<EMAIL_ADDRESS>>
+        password: <<PASSWORD>>
+        plantId: "<<PLAND_ID>>"
+mode: single

--- a/examples/automations/slow_charge_during_cheap_periods/solis_slow_charge_during_cheap_periods.yaml
+++ b/examples/automations/slow_charge_during_cheap_periods/solis_slow_charge_during_cheap_periods.yaml
@@ -32,12 +32,9 @@ actions:
     data:
       settings:
         - chargeCurrent: >-
-            {% set voltage = 50.0 %} # Your batteries' voltage.
-            {% set max_charge_amps = 37.5 %} # The maximum amps your batteries can charge.
-            # Octopus Cozy has two 3-hour slots and one 2-hour slot.  Figure out how
-            # many hours we have this slot.
+            {% set voltage = 50.0 %}
+            {% set max_charge_amps = 37.5 %}
             {% set charge_hours = 2 if now().hour > 16 and now().hour < 23 else 3 %}
-            # Calculate lowest amps to charge to get to 100% by the end.
             {% set battery_soc = float(states('sensor.solis_remaining_battery_capacity'), 0.0) %}
             {% set battery_percent_needed = (100.0 - battery_soc) | round(method="ceil") %}
             {% set watts_hours_needed = 3650 * (battery_percent_needed/100.0) %}


### PR DESCRIPTION
Include an example of using this script to charge your battery system at the slowest possible rate during your cheap slots in order to end the slot with the highest charge possible (hopefully 100%, but if the slot isn't long enough it will be less). 